### PR TITLE
correction ap_metric when tp is 0

### DIFF
--- a/src/kartezio/metric.py
+++ b/src/kartezio/metric.py
@@ -164,7 +164,7 @@ class MetricCellpose(KartezioMetric):
             fp[n] = n_pred[n] - tp[n]
             fn[n] = n_true[n] - tp[n]
             if tp[n] == 0:
-                if n_true[n] == 0:
+                if n_true[n] == 0 and fp[n] == 0:
                     ap[n] = 1.0
                 else:
                     ap[n] = 0.0


### PR DESCRIPTION
a condition is missing in case  the predict didn't find labels